### PR TITLE
fix: remove local django constraint

### DIFF
--- a/google_drive/__init__.py
+++ b/google_drive/__init__.py
@@ -4,4 +4,4 @@ Google drive XBlocks
 from .google_docs import GoogleDocumentBlock
 from .google_calendar import GoogleCalendarBlock
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -25,7 +25,6 @@ distlib==0.3.8
 django==3.2.23
     # via
     #   -c requirements/common_constraints.txt
-    #   -c requirements/constraints.txt
     #   edx-i18n-tools
 docopt==0.6.2
     # via coveralls
@@ -67,7 +66,7 @@ tomli==2.0.1
     # via
     #   pyproject-api
     #   tox
-tox==4.12.0
+tox==4.12.1
     # via -r requirements/ci.in
 typing-extensions==4.9.0
     # via asgiref

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,8 +11,4 @@
 -c common_constraints.txt
 
 # TODO: Many pinned dependencies should be unpinned and/or moved to this constraints file.
-
-# Use latest Django LTS version
-Django<3.3.0
-
 pylint==2.12.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,9 +18,9 @@ backports-functools-lru-cache==2.0.0
     # via caniusepython3
 binaryornot==0.4.4
     # via cookiecutter
-boto3==1.34.20
+boto3==1.34.25
     # via fs-s3fs
-botocore==1.34.20
+botocore==1.34.25
     # via
     #   boto3
     #   s3transfer
@@ -55,14 +55,13 @@ coverage[toml]==7.4.0
     #   pytest-cov
 ddt==1.7.1
     # via -r requirements/test.in
-diff-cover==8.0.2
+diff-cover==8.0.3
     # via -r requirements/dev.in
 distlib==0.3.8
     # via caniusepython3
 django==3.2.23
     # via
     #   -c requirements/common_constraints.txt
-    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   edx-i18n-tools
     #   openedx-django-pyfs
@@ -114,11 +113,11 @@ lxml==5.1.0
     #   edx-i18n-tools
     #   xblock
     #   xblock-sdk
-mako==1.3.0
+mako==1.3.1
     # via xblock
 markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.3
+markupsafe==2.1.4
     # via
     #   jinja2
     #   mako

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -18,9 +18,9 @@ backports-functools-lru-cache==2.0.0
     # via caniusepython3
 binaryornot==0.4.4
     # via cookiecutter
-boto3==1.34.20
+boto3==1.34.25
     # via fs-s3fs
-botocore==1.34.20
+botocore==1.34.25
     # via
     #   boto3
     #   s3transfer
@@ -55,14 +55,13 @@ coverage[toml]==7.4.0
     #   pytest-cov
 ddt==1.7.1
     # via -r requirements/test.in
-diff-cover==8.0.2
+diff-cover==8.0.3
     # via -r requirements/dev.in
 distlib==0.3.8
     # via caniusepython3
 django==3.2.23
     # via
     #   -c requirements/common_constraints.txt
-    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   edx-i18n-tools
     #   openedx-django-pyfs
@@ -114,11 +113,11 @@ lxml==5.1.0
     #   edx-i18n-tools
     #   xblock
     #   xblock-sdk
-mako==1.3.0
+mako==1.3.1
     # via xblock
 markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.3
+markupsafe==2.1.4
     # via
     #   jinja2
     #   mako

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,9 +12,9 @@ asgiref==3.7.2
     # via django
 binaryornot==0.4.4
     # via cookiecutter
-boto3==1.34.20
+boto3==1.34.25
     # via fs-s3fs
-botocore==1.34.20
+botocore==1.34.25
     # via
     #   boto3
     #   s3transfer
@@ -40,11 +40,10 @@ coverage[toml]==7.4.0
     #   pytest-cov
 ddt==1.7.1
     # via -r requirements/test.in
-diff-cover==8.0.2
+diff-cover==8.0.3
     # via -r requirements/dev.in
     # via
     #   -c requirements/common_constraints.txt
-    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   edx-i18n-tools
     #   openedx-django-pyfs
@@ -87,11 +86,11 @@ lxml==5.1.0
     #   edx-i18n-tools
     #   xblock
     #   xblock-sdk
-mako==1.3.0
+mako==1.3.1
     # via xblock
 markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.3
+markupsafe==2.1.4
     # via
     #   jinja2
     #   mako


### PR DESCRIPTION
## Description
- Local django constraints conflicts with the `django 4.2` [testing](https://github.com/openedx/edx-platform/actions/runs/7620158888/job/20754418534?pr=34093#step:10:1141) environment in edx-platform.
- Removed the local constraint which is also being inforced through the global constraints so it won't have any affect on the package itself.