### PR TITLE
fix: close modal on save [FC-0076]

### DIFF
--- a/google_drive/__init__.py
+++ b/google_drive/__init__.py
@@ -4,4 +4,4 @@ Google drive XBlocks
 from .google_docs import GoogleDocumentBlock
 from .google_calendar import GoogleCalendarBlock
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'

--- a/google_drive/public/js/google_calendar_edit.js
+++ b/google_drive/public/js/google_calendar_edit.js
@@ -84,8 +84,12 @@ function GoogleCalendarEditBlock(runtime, element) {
         error_message_div.html();
         error_message_div.css('display', 'none');
         var handlerUrl = runtime.handlerUrl(element, 'studio_submit');
+
+        runtime.notify('save', {state: 'start', message: gettext("Saving")});
+
         $.post(handlerUrl, JSON.stringify(data)).done(function(response) {
             if (response.result === 'success') {
+                runtime.notify('save', {state: 'end'})
                 window.location.reload(false);
             } else {
                 error_message_div.html('Error: '+response.message);

--- a/google_drive/public/js/google_calendar_edit.js
+++ b/google_drive/public/js/google_calendar_edit.js
@@ -92,6 +92,10 @@ function GoogleCalendarEditBlock(runtime, element) {
                 runtime.notify('save', {state: 'end'})
                 window.location.reload(false);
             } else {
+                runtime.notify('error', {
+                    'title': 'Error saving changes',
+                    'message': response.message,
+                });
                 error_message_div.html('Error: '+response.message);
                 error_message_div.css('display', 'block');
             }

--- a/google_drive/public/js/google_docs_edit.js
+++ b/google_drive/public/js/google_docs_edit.js
@@ -59,6 +59,10 @@ function GoogleDocumentEditBlock(runtime, element) {
                 runtime.notify('save', {state: 'end'})
                 window.location.reload(false);
             } else {
+                runtime.notify('error', {
+                    'title': 'Error saving changes',
+                    'message': response.message,
+                });
                 error_message_div.html('Error: '+response.message);
                 error_message_div.css('display', 'block');
             }

--- a/google_drive/public/js/google_docs_edit.js
+++ b/google_drive/public/js/google_docs_edit.js
@@ -51,8 +51,12 @@ function GoogleDocumentEditBlock(runtime, element) {
         error_message_div.html();
         error_message_div.css('display', 'none');
         var handlerUrl = runtime.handlerUrl(element, 'studio_submit');
+
+        runtime.notify('save', {state: 'start', message: gettext("Saving")});
+
         $.post(handlerUrl, JSON.stringify(data)).done(function(response) {
             if (response.result === 'success') {
+                runtime.notify('save', {state: 'end'})
                 window.location.reload(false);
             } else {
                 error_message_div.html('Error: '+response.message);


### PR DESCRIPTION
## Description
This PR fixes a bug in which the Edit dialog did not close after saving while on the Library Authoring pages.

## Testing Instruction
- Checkout this branch locally
- Add it to the tutor mount list using `tutor mounts add ./xblock-google-drive`
- Rebuild images using `tutor images build openedx-dev`
- Edit a Unit for a Course
- Go to `Settings > Advanced Settings on the header menu
- Make sure you have `google-document` and `google-calendar` on the "Advanced Module List"
![image](https://github.com/user-attachments/assets/d2edf77f-d020-4a05-a870-35618bc77560)
- Ensure you have `google-document` and `google-calendar` on the `LIBRARY_SUPPORTED_BLOCKS` on the `.env.development` file of the `frontend-app-authoring` mfe.
- Add a google-docs and google-calendar blocks to a Unit
- Copy these blocks and paste into a library
- Edit the blocks and check if the "Save" button closes the modal after clicking.

___
Private ref: [FAL-4031](https://tasks.opencraft.com/browse/FAL-4031)