### PR TITLE
build: add Django 5.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.11', '3.12']
-        toxenv: [django42, quality, package]
+        toxenv: [django42, django52, quality, package]
     steps:
     - name: Install translations dependencies
       run: sudo apt-get install -y gettext

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{311,312}-django{42},quality,package
+envlist = py{311,312}-django{42,52},quality,package
 
 [pycodestyle]
 exclude = .git,.tox
@@ -20,6 +20,7 @@ allowlist_externals =
     rm
 deps =
     django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
     -r{toxinidir}/requirements/test.txt
 setenv =
     DJANGO_SETTINGS_MODULE = workbench.settings


### PR DESCRIPTION
This adds Django 5.2 to the testing pipelines.

Resolves https://github.com/openedx/xblock-google-drive/issues/165