### PR TITLE
build: add info about Django 5.2 support and bump version

### DIFF
--- a/google_drive/__init__.py
+++ b/google_drive/__init__.py
@@ -4,4 +4,4 @@ Google drive XBlocks
 from .google_docs import GoogleDocumentBlock
 from .google_calendar import GoogleCalendarBlock
 
-__version__ = '0.8.0'
+__version__ = '0.8.1'

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,7 @@ setup(
         'Programming Language :: Python :: 3.12',
         'Framework :: Django',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
     ],
     url='https://github.com/openedx/xblock-google-drive',
     install_requires=load_requirements('requirements/base.in'),


### PR DESCRIPTION
This is a follow-up to https://github.com/openedx/xblock-google-drive/pull/166.

Resolves https://github.com/openedx/xblock-google-drive/issues/165